### PR TITLE
FAI-5896: Bump athena driver to 2.0.35 (#27878)

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -5,4 +5,5 @@
  {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}
 
  :deps
- {com.metabase/athena-jdbc {:mvn/version "2.0.33"}}}
+ {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.392"}
+  com.metabase/athena-jdbc {:mvn/version "2.0.35"}}}


### PR DESCRIPTION
* Bump athena driver to 2.0.35

* Include aws core for auth
