### PR TITLE
FAI-7872: Address vulnerabilties

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -95,7 +95,7 @@
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.0"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20220705"} ; Java implementation of the JQ json query language
-  org.apache.commons/commons-compress       {:mvn/version "1.24"}               ; compression utils
+  org.apache.commons/commons-compress       {:mvn/version "1.24.0"}             ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}             ; helper methods for working with java.lang stuff
   org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.19.0"}             ; apache logging framework
   org.apache.logging.log4j/log4j-api        {:mvn/version "2.19.0"}             ; add compatibility with log4j 1.2


### PR DESCRIPTION
Use correct version of [org.apache.commons/commons-compress:1.24.0](https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.24.0/)