### PR TITLE
FAI-7404: lock down user reports coln

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -35,8 +35,6 @@
    [metabase.models.timeline :as timeline :refer [Timeline]]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [trs]]
-   [metabase.util.log :as log]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.schema :as su]
    [schema.core :as s]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -907,10 +907,8 @@
 (defn- is-inside-pipeline-reports-coln
   "Check if the elements of collection's location match a pipeline reports collection."
   [collection]
-  (let [parents (some->> (str/split (:location collection) #"/")
-                         rest
-                         not-empty
-                         (map #(:name (db/select-one Collection :id (Integer/parseInt %)))))]
+  (let [parents (some->> (collection/location-path->ids (:location collection))
+                         (map #(:name (db/select-one Collection :id %))))]
     (and (= (count parents) 4)
          (= (take 2 parents) ["Aion", "Pipelines"])
          (= (last parents) "Reports"))))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -904,7 +904,7 @@
                             {:card-ids (db/select-ids Card :collection_id (u/the-id collection-before-update))}))]
       (api.card/delete-alert-and-notify-archived! alerts))))
 
-(defn- is-pipeline-reports-coln
+(defn- is-inside-pipeline-reports-coln
   "Check if the elements of collection's location match a pipeline reports collection."
   [collection]
   (let [parents (some->> (str/split (:location collection) #"/")
@@ -919,7 +919,7 @@
   "Check if the collection's name is 'User reports' and it is a pipeline reports collection."
   [collection]
   (and (= (:name collection) "User reports")
-       (is-pipeline-reports-coln collection)))
+       (is-inside-pipeline-reports-coln collection)))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/:id"


### PR DESCRIPTION
Added a check to prevent regular users from archiving or renaming the `User reports` collections.