### PR TITLE
Ensure deploy to dev is triggered regardless of target repo default input

### DIFF
--- a/.github/workflows/faros-build.yml
+++ b/.github/workflows/faros-build.yml
@@ -23,6 +23,9 @@ jobs:
               owner: 'faros-ai',
               repo: '${{ secrets.FAROS_METABASE_REPO }}',
               workflow_id: '${{ secrets.FAROS_METABASE_BUILD_WORKFLOW }}',
-              ref: '${{ secrets.FAROS_METABASE_BUILD_BRANCH }}'
+              ref: '${{ secrets.FAROS_METABASE_BUILD_BRANCH }}',
+              inputs: {
+                deploy_dev_enabled: "true"
+              }
             })
  


### PR DESCRIPTION
When the ci-cd workflow is run and calls workflow in another repo, we need to make sure it runs it with parameters we want.